### PR TITLE
fix(reader): raise HeaderNotFound eagerly at read() call site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xlea"
-version = "1.0.1"
+version = "1.0.2"
 description = "python library that makes it easy to convert Excel tables into ORM-like objects"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/core/test_lazy_header_not_found_bug.py
+++ b/tests/core/test_lazy_header_not_found_bug.py
@@ -1,0 +1,76 @@
+"""
+Regression tests for the lazy HeaderNotFound bug.
+
+Before the fix, `read()` and `autoread()` silently returned a generator
+when a schema was provided, deferring `BoundSchema.resolve()` — and therefore
+any `HeaderNotFound` / `MissingRequiredColumnError` — until the caller began
+iterating. The fix must make schema resolution errors surface eagerly, at the
+`read()` / `autoread()` call site.
+
+See: https://github.com/artanador/xlea/issues/3
+"""
+
+import pytest
+
+from xlea import Schema, Column, read
+from xlea.exc import HeaderNotFound
+
+
+class PersonSchema(Schema):
+    """Minimal schema used across all test cases."""
+
+    id: str = Column("ID")
+    name: str = Column("Name")
+
+
+class ListProvider:
+    """In-memory provider that wraps a plain list of tuples."""
+
+    def __init__(self, rows: list):
+        self._rows = rows
+
+    def rows(self):
+        return iter(self._rows)
+
+
+def test_read_raises_header_not_found_immediately_when_no_matching_header():
+    """
+    `read()` must raise `HeaderNotFound` at the call site, not during iteration,
+    when the provider yields no row that matches the required schema columns.
+
+    Arrange:
+        A provider whose rows contain no header matching PersonSchema
+        (columns "ID" and "Name" are absent).
+
+    Act:
+        Call `read()` with the schema — do NOT iterate.
+
+    Assert:
+        `HeaderNotFound` is raised before any iteration occurs.
+    """
+    provider = ListProvider(
+        [
+            ("Foo", "Bar"),
+            ("1", "Alice"),
+        ]
+    )
+
+    with pytest.raises(HeaderNotFound):
+        read(provider, schema=PersonSchema)
+
+
+def test_read_raises_header_not_found_immediately_when_rows_are_empty():
+    """
+    `read()` must raise `HeaderNotFound` eagerly when the provider yields
+    no rows at all.
+
+    Arrange:
+        A provider that yields an empty sequence.
+
+    Act / Assert:
+        `HeaderNotFound` is raised at the `read()` call site.
+    """
+    provider = ListProvider([])
+
+    with pytest.raises(HeaderNotFound):
+        read(provider, schema=PersonSchema)

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "xlea"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },

--- a/xlea/core/reader.py
+++ b/xlea/core/reader.py
@@ -55,9 +55,12 @@ def read(
 
     resolved_schema = BoundSchema(rows, schema).resolve()
     RowType = make_row_type(schema)
+    return _iter_rows(rows, resolved_schema, RowType)
 
+
+def _iter_rows(rows, resolved_schema: BoundSchema, row_type):
     for i, row in enumerate(rows[resolved_schema._data_row :]):
-        row_object = RowType(row, i, resolved_schema)
+        row_object = row_type(row, i, resolved_schema)
         if not hasattr(row_object, "row_index"):
             continue
         yield row_object


### PR DESCRIPTION
### Problem
 
`read()` and `autoread()` silently returned a generator when called with
a `schema`, deferring `BoundSchema.resolve()` until the first `next()`
call. Any schema resolution error (`HeaderNotFound`,
`MissingRequiredColumnError`) would only surface during iteration -
potentially far from the original call site, making the bug hard to
locate and the API contract unpredictable.

### Solution
 
Split `read()` into two parts:
 
- **Eager preamble** — row buffering and `resolve()` stay in `read()` as
  a plain function; errors surface immediately at the call site.
- **Lazy iteration** — extracted into a private `_iter_rows()` generator;
  large files are still streamed row-by-row without loading everything
  into memory.
 
```python
def read(provider, schema=None):
    rows = provider.rows()
    if schema is None:
        return rows
    if not isinstance(rows, tuple):
        rows = tuple(rows)
    resolved_schema = BoundSchema(rows, schema).resolve()  # eager
    return _iter_rows(rows, resolved_schema, make_row_type(schema))
 
def _iter_rows(rows, resolved_schema, RowType):          # lazy
    for i, row in enumerate(rows[resolved_schema._data_row:]):
        row_object = RowType(row, i, resolved_schema)
        if not hasattr(row_object, "row_index"):
            continue
        yield row_object
```
 
`autoread()` delegates to `read()` and is fixed automatically.
 
### Changes
 
- `xlea/core/reader.py` — split `read()` into eager preamble + `_iter_rows()`

Closes #3 